### PR TITLE
Handle KEF password reauth failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Current live validation is strongest on LSX II, but broad KEF coverage is the go
 2. Restart Home Assistant.
 3. Add the integration from `Settings -> Devices & services`.
 
+### KEF Web UI Passwords
+
+Recent KEF firmware can require a password for the speaker web interface and
+local API writes. If your speaker has web UI password protection enabled, enter
+that password when adding or reconfiguring the integration. If the speaker starts
+requiring a password after a firmware update, Home Assistant will ask you to
+reauthenticate the KEF integration.
+
 ## ✅ Current Status
 
 - strongest real-device validation today: LSX II

--- a/custom_components/kef/__init__.py
+++ b/custom_components/kef/__init__.py
@@ -10,12 +10,13 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
 
 from .const import (
+    AUTH_FAILURE_MESSAGE,
     CONF_ENABLE_DIAGNOSTICS,
     DEFAULT_ENABLE_DIAGNOSTICS,
     DOMAIN,
 )
 from .coordinator import KefConfigEntry, KefCoordinator
-from .exceptions import KefError
+from .exceptions import KefAuthenticationRequiredError, KefError
 
 PLATFORMS = [
     Platform.MEDIA_PLAYER,
@@ -105,6 +106,9 @@ async def _async_handle_install_firmware_file(
             call.data[ATTR_FIRMWARE_FILE_PATH]
         )
         await coordinator.async_request_refresh()
+    except KefAuthenticationRequiredError as err:
+        config_entry.async_start_reauth(hass)
+        raise HomeAssistantError(AUTH_FAILURE_MESSAGE) from err
     except KefError as err:
         raise HomeAssistantError(str(err)) from err
 

--- a/custom_components/kef/config_flow.py
+++ b/custom_components/kef/config_flow.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Any
 
 import voluptuous as vol
-from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
+    ConfigFlow,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -111,6 +116,47 @@ class KefConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
+    async def async_step_reauth(self, entry_data: dict[str, Any]):
+        """Handle a request to update KEF credentials."""
+        entry = self._get_reauth_entry()
+        self._host = entry.data[CONF_HOST]
+        self._password = entry.options.get(
+            CONF_PASSWORD,
+            entry.data.get(CONF_PASSWORD, ""),
+        )
+        self._title = entry.title
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ):
+        """Confirm updated KEF credentials."""
+        self._errors = {}
+        entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            self._host = entry.data[CONF_HOST]
+            self._password = user_input.get(CONF_PASSWORD, "")
+            if await self._async_validate_host():
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates=self._entry_data,
+                    options={**entry.options, CONF_PASSWORD: self._password},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_PASSWORD, default=self._password): str,
+                }
+            ),
+            errors=self._errors,
+            description_placeholders={"title": self._title},
+            last_step=True,
+        )
+
     async def async_step_zeroconf(self, discovery_info: ZeroconfServiceInfo):
         """Handle zeroconf discovery."""
         if discovery_info.type != AIRPLAY_ZEROCONF_TYPE:
@@ -189,7 +235,7 @@ class KefConfigFlow(ConfigFlow, domain=DOMAIN):
             return None
 
         await self.async_set_unique_id(device.unique_id)
-        if self.source == SOURCE_RECONFIGURE:
+        if self.source in {SOURCE_REAUTH, SOURCE_RECONFIGURE}:
             self._abort_if_unique_id_mismatch()
         else:
             self._abort_if_unique_id_configured(updates={CONF_HOST: self._host})

--- a/custom_components/kef/const.py
+++ b/custom_components/kef/const.py
@@ -8,6 +8,11 @@ AUTH_MODE_SETDATA = "setData"
 
 DOMAIN = "kef"
 
+AUTH_FAILURE_MESSAGE = (
+    "KEF speaker requires a valid web UI password. Reconfigure the KEF "
+    "integration and enter the password configured in the speaker web interface."
+)
+
 DEFAULT_PORT = 80
 DEFAULT_SCAN_INTERVAL_SECONDS = 10
 MIN_SCAN_INTERVAL_SECONDS = 5

--- a/custom_components/kef/coordinator.py
+++ b/custom_components/kef/coordinator.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -18,7 +19,7 @@ from .const import (
     CONF_TCP_PORT,
     DEFAULT_SCAN_INTERVAL_SECONDS,
 )
-from .exceptions import KefError
+from .exceptions import KefAuthenticationRequiredError, KefError
 from .models import KefBackend, KefSnapshot
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,6 +67,8 @@ class KefCoordinator(DataUpdateCoordinator[KefSnapshot]):
 
         try:
             return await self.client.async_refresh()
+        except KefAuthenticationRequiredError as err:
+            raise ConfigEntryAuthFailed(str(err)) from err
         except KefError as err:
             raise UpdateFailed(str(err)) from err
 

--- a/custom_components/kef/entity.py
+++ b/custom_components/kef/entity.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import AUTH_FAILURE_MESSAGE
 from .coordinator import KefCoordinator
+from .exceptions import KefAuthenticationRequiredError, KefError
+
+_T = TypeVar("_T")
 
 
 class KefEntity:
@@ -13,6 +22,16 @@ class KefEntity:
     def __init__(self, coordinator: KefCoordinator) -> None:
         """Initialize the entity."""
         self.coordinator = coordinator
+
+    async def async_call_kef(self, action: Callable[[], Awaitable[_T]]) -> _T:
+        """Run a KEF client action and surface integration-friendly errors."""
+        try:
+            return await action()
+        except KefAuthenticationRequiredError as err:
+            self.coordinator.config_entry.async_start_reauth(self.coordinator.hass)
+            raise HomeAssistantError(AUTH_FAILURE_MESSAGE) from err
+        except KefError as err:
+            raise HomeAssistantError(str(err)) from err
 
     @property
     def device_info(self):

--- a/custom_components/kef/media_player.py
+++ b/custom_components/kef/media_player.py
@@ -278,12 +278,12 @@ class KefMediaPlayer(KefEntity, CoordinatorEntity[KefCoordinator], MediaPlayerEn
 
     async def async_turn_on(self) -> None:
         """Turn on the speaker."""
-        await self.coordinator.client.async_turn_on()
+        await self.async_call_kef(self.coordinator.client.async_turn_on)
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self) -> None:
         """Turn off the speaker."""
-        await self.coordinator.client.async_turn_off()
+        await self.async_call_kef(self.coordinator.client.async_turn_off)
         await self.coordinator.async_request_refresh()
 
     async def async_set_volume_level(self, volume: float) -> None:
@@ -291,19 +291,29 @@ class KefMediaPlayer(KefEntity, CoordinatorEntity[KefCoordinator], MediaPlayerEn
         raw_volume = round(max(0.0, min(1.0, volume)) * 100)
         if raw_volume > 0:
             self._last_volume_before_mute = raw_volume
-        await self.coordinator.client.async_set_volume_raw(raw_volume)
+        await self.async_call_kef(
+            lambda: self.coordinator.client.async_set_volume_raw(raw_volume)
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_volume_up(self) -> None:
         """Raise the volume."""
         current = self.coordinator.data.volume_raw or 0
-        await self.coordinator.client.async_set_volume_raw(min(100, current + 4))
+        await self.async_call_kef(
+            lambda: self.coordinator.client.async_set_volume_raw(
+                min(100, current + 4)
+            )
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_volume_down(self) -> None:
         """Lower the volume."""
         current = self.coordinator.data.volume_raw or 0
-        await self.coordinator.client.async_set_volume_raw(max(0, current - 4))
+        await self.async_call_kef(
+            lambda: self.coordinator.client.async_set_volume_raw(
+                max(0, current - 4)
+            )
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_mute_volume(self, mute: bool) -> None:
@@ -311,32 +321,40 @@ class KefMediaPlayer(KefEntity, CoordinatorEntity[KefCoordinator], MediaPlayerEn
         current = self.coordinator.data.volume_raw or 0
         if not mute and current == 0:
             self._last_volume_before_mute = max(1, self._last_volume_before_mute)
-        await self.coordinator.client.async_set_muted(mute)
+        await self.async_call_kef(
+            lambda: self.coordinator.client.async_set_muted(mute)
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_select_source(self, source: str) -> None:
         """Select the input source."""
-        await self.coordinator.client.async_select_source(source)
+        await self.async_call_kef(
+            lambda: self.coordinator.client.async_select_source(source)
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_media_play(self) -> None:
         """Play or resume playback."""
         if self.state != MediaPlayerState.PLAYING:
-            await self.coordinator.client.async_toggle_play_pause()
+            await self.async_call_kef(
+                self.coordinator.client.async_toggle_play_pause
+            )
             await self.coordinator.async_request_refresh()
 
     async def async_media_pause(self) -> None:
         """Pause playback."""
         if self.state == MediaPlayerState.PLAYING:
-            await self.coordinator.client.async_toggle_play_pause()
+            await self.async_call_kef(
+                self.coordinator.client.async_toggle_play_pause
+            )
             await self.coordinator.async_request_refresh()
 
     async def async_media_next_track(self) -> None:
         """Skip to the next track."""
-        await self.coordinator.client.async_next_track()
+        await self.async_call_kef(self.coordinator.client.async_next_track)
         await self.coordinator.async_request_refresh()
 
     async def async_media_previous_track(self) -> None:
         """Go to the previous track."""
-        await self.coordinator.client.async_previous_track()
+        await self.async_call_kef(self.coordinator.client.async_previous_track)
         await self.coordinator.async_request_refresh()

--- a/custom_components/kef/number.py
+++ b/custom_components/kef/number.py
@@ -269,7 +269,9 @@ class KefNumber(KefEntity, CoordinatorEntity[KefCoordinator], NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the number value."""
-        await self.entity_description.async_set_fn(self.coordinator, value)
+        await self.async_call_kef(
+            lambda: self.entity_description.async_set_fn(self.coordinator, value)
+        )
         await self.coordinator.async_request_refresh()
 
 
@@ -320,5 +322,9 @@ class KefSourceVolumeNumber(KefEntity, CoordinatorEntity[KefCoordinator], Number
         client = self.coordinator.client
         if client is None:
             return
-        await client.async_set_default_volume_for_source(self._source, round(value))
+        await self.async_call_kef(
+            lambda: client.async_set_default_volume_for_source(
+                self._source, round(value)
+            )
+        )
         await self.coordinator.async_request_refresh()

--- a/custom_components/kef/select.py
+++ b/custom_components/kef/select.py
@@ -295,5 +295,9 @@ class KefSelect(KefEntity, CoordinatorEntity[KefCoordinator], SelectEntity):
             for raw, friendly in self.entity_description.options_map.items()
         }
         raw_value = reverse_map.get(option, option)
-        await self.entity_description.async_set_fn(self.coordinator, raw_value)
+        await self.async_call_kef(
+            lambda: self.entity_description.async_set_fn(
+                self.coordinator, raw_value
+            )
+        )
         await self.coordinator.async_request_refresh()

--- a/custom_components/kef/switch.py
+++ b/custom_components/kef/switch.py
@@ -456,10 +456,14 @@ class KefSwitch(KefEntity, CoordinatorEntity[KefCoordinator], SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
-        await self.entity_description.async_set_fn(self.coordinator, True)
+        await self.async_call_kef(
+            lambda: self.entity_description.async_set_fn(self.coordinator, True)
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
-        await self.entity_description.async_set_fn(self.coordinator, False)
+        await self.async_call_kef(
+            lambda: self.entity_description.async_set_fn(self.coordinator, False)
+        )
         await self.coordinator.async_request_refresh()

--- a/custom_components/kef/text.py
+++ b/custom_components/kef/text.py
@@ -110,5 +110,7 @@ class KefText(KefEntity, CoordinatorEntity[KefCoordinator], TextEntity):
 
     async def async_set_value(self, value: str) -> None:
         """Set the text value."""
-        await self.entity_description.async_set_fn(self.coordinator, value)
+        await self.async_call_kef(
+            lambda: self.entity_description.async_set_fn(self.coordinator, value)
+        )
         await self.coordinator.async_request_refresh()

--- a/custom_components/kef/translations/en.json
+++ b/custom_components/kef/translations/en.json
@@ -20,6 +20,13 @@
           "host": "Host or IP address",
           "password": "Web UI password"
         }
+      },
+      "reauth_confirm": {
+        "title": "Update KEF password",
+        "description": "Enter the web UI password for {title}.",
+        "data": {
+          "password": "Web UI password"
+        }
       }
     },
     "error": {
@@ -29,6 +36,7 @@
     },
     "abort": {
       "already_configured": "This KEF speaker is already configured",
+      "reauth_successful": "The KEF password was updated",
       "unsupported": "This discovered device is not a supported KEF speaker"
     }
   },

--- a/custom_components/kef/update.py
+++ b/custom_components/kef/update.py
@@ -95,5 +95,7 @@ class KefFirmwareUpdateEntity(
         **kwargs,
     ) -> None:
         """Install the available firmware update."""
-        await self.coordinator.client.async_install_firmware_update()
+        await self.async_call_kef(
+            self.coordinator.client.async_install_firmware_update
+        )
         await self.coordinator.async_request_refresh()

--- a/tests/components/kef/test_config_flow.py
+++ b/tests/components/kef/test_config_flow.py
@@ -255,6 +255,66 @@ async def test_reconfigure_updates_password_options(monkeypatch, hass) -> None:
     assert entry.options[CONF_PASSWORD] == "new-secret"
 
 
+async def test_reauth_updates_password_options(monkeypatch, hass) -> None:
+    """Reauth should prompt for and store a replacement web UI password."""
+
+    async def fake_create_client(
+        host,
+        session,
+        *,
+        backend=None,
+        port=None,
+        password=None,
+        tcp_port=None,
+    ):
+        assert host == TEST_HOST
+        assert password == "fixed-secret"
+        return _FakeClient()
+
+    monkeypatch.setattr(
+        "custom_components.kef.config_flow.async_create_client",
+        fake_create_client,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_DEVICE_INFO.unique_id,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_PORT: 80,
+            CONF_TCP_PORT: 50001,
+            CONF_BACKEND: "modern",
+            CONF_DEVICE_ID: TEST_DEVICE_INFO.unique_id,
+            CONF_PASSWORD: "old-secret",
+        },
+        options={CONF_PASSWORD: "old-secret"},
+        title=TEST_DEVICE_INFO.device_name,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+        },
+        data=entry.data,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "fixed-secret"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_PASSWORD] == "fixed-secret"
+    assert entry.options[CONF_PASSWORD] == "fixed-secret"
+
+
 async def test_zeroconf_updates_existing_entry_using_deviceid(hass) -> None:
     """Discovered speakers should match the configured MAC-based unique ID."""
 

--- a/tests/components/kef/test_coordinator.py
+++ b/tests/components/kef/test_coordinator.py
@@ -6,6 +6,7 @@ import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.kef.const import (
@@ -14,6 +15,7 @@ from custom_components.kef.const import (
     DOMAIN,
 )
 from custom_components.kef.coordinator import KefCoordinator
+from custom_components.kef.exceptions import KefAuthenticationRequiredError
 from custom_components.kef.models import KefBackend
 from tests.conftest import TEST_HOST, TEST_PORT
 
@@ -58,3 +60,27 @@ async def test_event_listener_requests_refresh_on_events(hass) -> None:
         await coordinator._async_event_listener_loop()
 
     coordinator.async_request_refresh.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_update_data_raises_config_entry_auth_failed(hass) -> None:
+    """Authentication failures should trigger Home Assistant reauth."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": TEST_HOST,
+            "port": TEST_PORT,
+            CONF_TCP_PORT: 50001,
+            CONF_BACKEND: "modern",
+        },
+        title="KEF",
+    )
+    coordinator = KefCoordinator(hass, entry)
+    coordinator.client = AsyncMock()
+    coordinator.client.async_refresh.side_effect = KefAuthenticationRequiredError(
+        "password required"
+    )
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()

--- a/tests/components/kef/test_media_player.py
+++ b/tests/components/kef/test_media_player.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from copy import deepcopy
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from homeassistant.components.media_player import MediaPlayerEntityFeature
+from homeassistant.exceptions import HomeAssistantError
 
+from custom_components.kef.exceptions import KefAuthenticationRequiredError
 from custom_components.kef.media_player import KefMediaPlayer
 from tests.conftest import TEST_SNAPSHOT
 
@@ -17,7 +19,11 @@ def _build_player(snapshot):
     coordinator = Mock()
     coordinator.data = snapshot
     coordinator.last_update_success = True
-    coordinator.config_entry = SimpleNamespace(domain="kef")
+    coordinator.config_entry = SimpleNamespace(
+        domain="kef",
+        async_start_reauth=Mock(),
+    )
+    coordinator.hass = Mock()
     return KefMediaPlayer(coordinator)
 
 
@@ -63,3 +69,27 @@ def test_legacy_supported_features_keep_transport_controls() -> None:
     assert player.supported_features & MediaPlayerEntityFeature.PAUSE
     assert player.supported_features & MediaPlayerEntityFeature.NEXT_TRACK
     assert player.supported_features & MediaPlayerEntityFeature.PREVIOUS_TRACK
+
+
+async def test_volume_auth_failure_starts_reauth() -> None:
+    """Runtime auth failures should start reauth and raise a HA error."""
+    snapshot = deepcopy(TEST_SNAPSHOT)
+    player = _build_player(snapshot)
+    player.coordinator.client = SimpleNamespace(
+        async_set_volume_raw=AsyncMock(
+            side_effect=KefAuthenticationRequiredError("bad password")
+        )
+    )
+    player.coordinator.async_request_refresh = AsyncMock()
+
+    try:
+        await player.async_set_volume_level(0.5)
+    except HomeAssistantError as err:
+        assert "valid web UI password" in str(err)
+    else:
+        raise AssertionError("Expected HomeAssistantError")
+
+    player.coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        player.coordinator.hass
+    )
+    player.coordinator.async_request_refresh.assert_not_awaited()

--- a/tests/components/kef/test_services.py
+++ b/tests/components/kef/test_services.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
+import pytest
 from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -15,6 +17,7 @@ from custom_components.kef import (
     _async_register_services,
 )
 from custom_components.kef.const import DOMAIN
+from custom_components.kef.exceptions import KefAuthenticationRequiredError
 
 
 async def test_install_firmware_file_service_uploads_to_update_entity(hass) -> None:
@@ -54,3 +57,46 @@ async def test_install_firmware_file_service_uploads_to_update_entity(hass) -> N
         "/config/firmware/LSXII_V30135.swu"
     )
     coordinator.async_request_refresh.assert_awaited_once_with()
+
+
+async def test_install_firmware_file_auth_failure_starts_reauth(hass) -> None:
+    """Firmware upload auth failures should trigger reauth cleanly."""
+    config_entry = MockConfigEntry(domain=DOMAIN, title="KEF")
+    config_entry.add_to_hass(hass)
+    config_entry.async_start_reauth = Mock()
+
+    client = SimpleNamespace(
+        async_upload_firmware_update=AsyncMock(
+            side_effect=KefAuthenticationRequiredError("password required")
+        )
+    )
+    coordinator = SimpleNamespace(
+        client=client,
+        async_request_refresh=AsyncMock(),
+    )
+    config_entry.runtime_data = coordinator
+
+    registry = er.async_get(hass)
+    entity_entry = registry.async_get_or_create(
+        Platform.UPDATE,
+        DOMAIN,
+        "kef-84:17:15:04:43:8c_firmware",
+        config_entry=config_entry,
+        suggested_object_id="kef_firmware",
+    )
+
+    _async_register_services(hass)
+
+    with pytest.raises(HomeAssistantError, match="valid web UI password"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_INSTALL_FIRMWARE_FILE,
+            {
+                ATTR_ENTITY_ID: entity_entry.entity_id,
+                ATTR_FIRMWARE_FILE_PATH: "/config/firmware/LSXII_V30135.swu",
+            },
+            blocking=True,
+        )
+
+    config_entry.async_start_reauth.assert_called_once_with(hass)
+    coordinator.async_request_refresh.assert_not_awaited()


### PR DESCRIPTION
## Summary
- trigger Home Assistant reauth when KEF auth/password failures happen during coordinator refresh or runtime writes
- add a password reauth flow and translations for updating the KEF web UI password
- wrap entity/service KEF calls so bad or missing passwords surface as clear Home Assistant errors instead of raw tracebacks
- document recent firmware password behavior and add focused regression tests

## Validation
- ruff check custom_components tests
- python -m compileall custom_components tests
- pytest was attempted locally but the Windows environment cannot load pytest-homeassistant-custom-component because it imports fcntl